### PR TITLE
[refactor/OpenWeatherAPI] 각 지역 별 날씨 정보 가져오기

### DIFF
--- a/wanted_pre_onboarding/wanted_pre_onboarding/Controllers/HomeViewController.swift
+++ b/wanted_pre_onboarding/wanted_pre_onboarding/Controllers/HomeViewController.swift
@@ -39,29 +39,25 @@ class HomeViewController: UIViewController {
     
     func fetchWeather(idDict: [Int: (Int, String)]) {
         self.weatherInfoList = []
-        var cityId = ""
-        var cnt = 0
+        let cityNum = self.cityInfoDict.count
         for (id, (_, _)) in idDict {
-            cityId += ("\(id),")
-            cnt += 1
-            // Group 으로 받아올 수 있는 최대 지역의 개수가 19개
-            if (cnt % 19 == 0 || cnt == cityInfoDict.count) {
-                WeatherService.shared.getWeatherList(cityID: cityId) { result in
-                    switch result {
-                    case .success(let weatherResponseList):
-                        weatherResponseList.list.forEach { self.weatherInfoList.append((self.cityInfoDict[$0.id]?.0, $0)) }
+            WeatherService.shared.getWeather(cityID: id) { result in
+                switch result {
+                case .success(let weatherResponse):
+                    self.weatherInfoList.append((self.cityInfoDict[weatherResponse.id]?.0, weatherResponse))
+                    
+                    if self.weatherInfoList.count == cityNum {
                         DispatchQueue.main.async {
                             self.weatherInfoList.sort { $0.0 ?? 0 < $1.0 ?? 1 }
                             self.homeView.weatherInfoCollectionView.reloadData()
                         }
-                    case .failure(_):
-                        print("==============================")
-                        print("=====HomeViewController:fetchWeather=====")
-                        print("=====WeatherResponseList 를 불러올 수 없습니다.=====")
-                        print("==============================")
                     }
+                case .failure(_):
+                    print("==============================")
+                    print("=====HomeViewController:fetchWeather=====")
+                    print("=====WeatherResponse 를 불러올 수 없습니다.=====")
+                    print("==============================")
                 }
-                cityId = ""
             }
         }
     }

--- a/wanted_pre_onboarding/wanted_pre_onboarding/Models/Weather.swift
+++ b/wanted_pre_onboarding/wanted_pre_onboarding/Models/Weather.swift
@@ -5,11 +5,6 @@
 //  Created by 김승찬 on 2022/09/06.
 //
 
-
-struct WeatherResponseList: Decodable {
-    let list: [WeatherResponse]
-}
-
 struct WeatherResponse: Decodable {
     let weather: [WeatherSummary]
     let main: Weather

--- a/wanted_pre_onboarding/wanted_pre_onboarding/Service/WeatherService.swift
+++ b/wanted_pre_onboarding/wanted_pre_onboarding/Service/WeatherService.swift
@@ -20,8 +20,8 @@ class WeatherService {
     
     private let APIKey = "086e3b00efd5c9d4dd31883ac4ac3772"
     
-    func getWeatherList(cityID: String, completion: @escaping (Result<WeatherResponseList, NetworkError>) -> Void) {
-        let url = URL(string: "https://api.openweathermap.org/data/2.5/group?id=\(cityID)&appid=\(APIKey)&units=metric")
+    func getWeather(cityID: Int, completion: @escaping (Result<WeatherResponse, NetworkError>) -> Void) {
+        let url = URL(string: "https://api.openweathermap.org/data/2.5/weather?id=\(cityID)&units=metric&appid=\(APIKey)")
         
         guard let url = url else {
             return completion(.failure(.badUrl))
@@ -32,9 +32,9 @@ class WeatherService {
                 return completion(.failure(.noData))
             }
             
-            let weatherResponseList = try? JSONDecoder().decode(WeatherResponseList.self, from: data)
-            if let weatherResponseList = weatherResponseList {
-                completion(.success(weatherResponseList))
+            let weatherResponse = try? JSONDecoder().decode(WeatherResponse.self, from: data)
+            if let weatherResponse = weatherResponse {
+                completion(.success(weatherResponse))
             } else {
                 completion(.failure(.decodingError))
             }


### PR DESCRIPTION
# [refactor/OpenWeatherAPI] 각 지역 별 날씨 정보 가져오기
## 개발 환경  
* Xcode 13.4.1  
* iOS 15.6  
* iPhone SE, Simulator  

## 변경 전  
* WeatherService  
  * 도시 id 가 각각 `1, 2, 3` 이라고 했을 때, `group?id=1,2,3` 을 통해 한꺼번에 날씨 정보를 가져옴 (최대 19개 지역)  
  * `https://api.openweathermap.org/data/2.5/group?id=1,2,3&appid=\(APIKey)&units=metric`  
* Model  
  * `WeatherResponse` 그룹을 처리하기 위해 `WeatherResponseList` 를 사용  

## 변경 후  
* WeatherService  
  * 도시 id 가 각각 '1, 2, 3' 이라고 했을 때, `id=1`, `id=2`, `id=3` 로 각각 정보를 가져옴  
  * `https://api.openweathermap.org/data/2.5/weather?id=1&units=metric&appid=\(APIKey)`  
  * `https://api.openweathermap.org/data/2.5/weather?id=2&units=metric&appid=\(APIKey)`  
  * `https://api.openweathermap.org/data/2.5/weather?id=3&units=metric&appid=\(APIKey)`  
* Model  
  * `WeatherResponseList` 삭제  

## 변경 이유  
* [OpenWeatherAPI](https://openweathermap.org/current) 내부에 `group?id=` 관련 문서가 삭제됨  
* 예를 들어 id가 1일 때, 같은 도시에 대한 `weather?id=1` 정보와 `group?id=1` 정보가 서로 다름  